### PR TITLE
Adds notes on rfsearch and rfci

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -26,7 +26,9 @@ Contents
    databases
    seq_search
    text_search
-
+   rfsearch
+   rfci
+   
 .. _release:
 .. toctree::
    :titlesonly:

--- a/source/rfci.md
+++ b/source/rfci.md
@@ -1,0 +1,35 @@
+# `rfci.pl` notes
+
+For large families, it is recommended you login to a node with at
+least 64G of RAM (`bsub -M 64000M -q research -Is $SHELL`). The
+overlap check requires a lot of RAM. There may be other steps that
+require a lot of RAM as well.
+
+Table of running times for commits (`rfci.pl`) (compiled 10/22:
+
+| acc     | family id              | seed #seq | full #seq | `rfci.pl` flags*  | runtime |
+| ------- | ---------------------- | --------- | --------- | ----------------- | ------- |
+| RF00177 | SSU_rRNA_bacteria      |  99       | 37125     | `-i coding -i overlap` | 17 min |
+| RF01960 | SSU_rRNA_eukarya       |  90       | 39618     | `-i coding -i overlap` |  9 min |
+| RF02540 | LSU_rRNA_archaea       |  91       | 48683     | `-i coding -i overlap` | 23 min |
+| RF02542 | SSU_rRNA_microsporidia |  46       | 35934     | `-i coding -i overlap` | 11 min |
+| RF02543 | LSU_rRNA_eukarya       |  88       | 54013     | `-i coding -i overlap` |  7 min |
+| RF03064 | RAGATH-18              | 1420      | 1771      |                        | 9 min  |
+
+* `-i spell -i missing -preseed` also used for *all* above `rfci.pl` commands
+
+---
+
+Miscellaneous notes:
+
+Jiffy script that loads info to RfamLive:
+`/homes/nawrocki/git/Rfam/rfam-family-pipeline/Rfam/Scripts/jiffies/update_seed_dependent_tables_for_family.pl`
+
+Note this is only a local file not in the git repo.
+
+Code that updates the RfamLive tables is here:
+
+Rfam/Schemata/{RfamLive,RfamDB}/ResultSet/Taxonomy.pm
+Rfam/Schemata/{RfamLive,RfamDB}/ResultSet/SeedRegion.pm
+Rfam/Schemata/{RfamLive,RfamDB}/ResultSet/Rfamseq.pm
+Rfam/Schemata/{RfamLive,RfamDB}/ResultSet/RnacentralMatch.pm

--- a/source/rfsearch.md
+++ b/source/rfsearch.md
@@ -1,0 +1,22 @@
+# `rfsearch.pl` notes
+
+Families which require special `rfsearch.pl` flags:
+
+| accession | recommended command              | reason |
+| --------- | -------------------------------- | ------ |
+| RF00017   |  `rfsearch.pl -ignoresm -cut_ga` | too many hits otherwise, and it takes more than 1 week |
+| RF02543   |  `rfsearch.pl -cgtailn 200`      | allows calibration to finish successfully, otherwise you get this error 'Error: --gtailn <n>=250 cannot be used, there's only 215.000 hits per Mb in the histogram! Lower <n> or use --tailp.' |
+
+---
+
+Possible `rfsearch.pl` error: 
+```
+ERROR unable to fetch description for JZJH011 at /homes/nawrocki/git/Rfam/rfam-family-pipeline/Rfam/Lib/Bio/Rfam/FamilyIO.pm line 2070, <RTBL> line 48.
+```
+
+If you see an error like this: rerun with `-scpu 0`. This error is
+due to a bug in infernal 1.1.4 (actually in easel) that was fixed in
+commit 8d300ef, so should be fixed in next release of infernal.
+https://github.com/EddyRivasLab/easel/pull/66/commits/8d300ef3899f69365be02635416333d0f30ccbe9
+
+


### PR DESCRIPTION
I added some notes on rfsearch/rfci to the internal docs based on my experience with running rfco/rfsearch/rfmake/rfci on some of the big families. I was hoping to see how these looked when rendered but I think it is only possible to see the markdown rendered for the main branch, here: https://rfam-internal-docs.readthedocs.io/en/latest/.

If you're ok with these changes, please merge them and let me know if you're ok with me committing directly to main, so I can tweak how they look when rendered. Thanks.
